### PR TITLE
Improve Conversational AI demo page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="cs">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Ukázka ElevenLabs Conversational AI</title>
+    <style>
+        html, body {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+        }
+        .background {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border: none;
+            z-index: -1;
+        }
+        .content {
+            position: relative;
+            z-index: 1;
+            padding: 20px;
+            color: #000;
+        }
+    </style>
+</head>
+<body>
+    <!-- Background iframe -->
+    <iframe src="https://dek.cz/" class="background"></iframe>
+
+    <div class="content">
+        <h1>Ukázka ElevenLabs Conversational AI</h1>
+        <p>Toto je testovací rozhraní.</p>
+        <p>Tento příklad ukazuje, jak můžete na webovou stránku vložit widget <strong>Conversational AI</strong> od ElevenLabs.</p>
+
+        <!-- Embed the ElevenLabs convai widget -->
+        <elevenlabs-convai agent-id="agent_01jwarxh25ffkvwyghwr3e59vb"></elevenlabs-convai>
+        <script src="https://unpkg.com/@elevenlabs/convai-widget-embed" async type="text/javascript"></script>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enhance HTML demo with iframe background from `dek.cz`
- add notice that the page is a test interface
- keep ElevenLabs Conversational AI widget embed

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_6847bb6618cc8325b977411a5cdd377c